### PR TITLE
chore: add warning in Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,13 @@
+<!---
+❌❌❌
+WARNING!!!
+Make sure the base repository is `rootstrap/react-native-template` BEFORE creating the Pull Request.
+❌❌❌
+-->
+
+
+
+
 ## What does this do?
 
 <!---


### PR DESCRIPTION
## What does this do?

This PR adds a warning comment in the GitHub's Pull Request Template to remind about selecting this repository (`https://github.com/rootstrap/react-native-template`) as base branch instead of the upstream repository (`https://github.com/obytes/react-native-template-obytes`)

## Why did you do this?

I made this change because I accidentally created a Pull Request in the wrong repository, and there's no way to change what is the default base branch when creating a new Pull Request.

