### PR TITLE
chore: update-action-version

### DIFF
--- a/.github/actions/setup-node-pnpm-install/action.yml
+++ b/.github/actions/setup-node-pnpm-install/action.yml
@@ -16,10 +16,10 @@ description: 'Setup  Node + PNPM + Install Dependencies'
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@v2
-      with:
-        version: 8
-    - uses: actions/setup-node@v3
+    - uses: pnpm/action-setup@v4
+      name: Install pnpm
+    - uses: actions/setup-node@v4
+      name: Install Node.js
       with:
         node-version: 18
         cache: 'pnpm'


### PR DESCRIPTION
## What does this do?

Update the version of actions being used in github workflows.

## Why did you do this?

On projects created by the current cli the github actions are failing.

![Untitled](https://prod-files-secure.s3.us-west-2.amazonaws.com/cf3618fe-4689-42ab-8d73-f4ea88b8ed8b/b04b4d73-d4b4-4d66-89a5-ad932e32a8ca/Untitled.png)

## Who/what does this impact?

Github workflows

## How did you test this?

The change was made on a project created using the CLI  until the actions passed.

You can check the result [here](https://github.com/fernandatoledo/MyApp/pull/1)

![Screenshot 2024-07-09 at 1 30 01 PM](https://github.com/obytes/react-native-template-obytes/assets/13571788/37424a1f-f495-42f5-a3d0-84e0203e640d)

