### PR TITLE
chore: setup sonar scanner

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,46 @@
+name: SonarQube analysis
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
+      - master
+      - staging
+      - qa
+      - development
+
+env:
+  SONAR_PROJECT: myapp-delete
+
+jobs:
+  sonar:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📦 Checkout project repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: 📦 Setup Node + PNPM + install deps
+        uses: ./.github/actions/setup-node-pnpm-install
+
+      - name: Run Tests
+        run: export NODE_OPTIONS=--experimental-vm-modules && pnpm test:ci
+
+      - name: SonarQube Scan
+        uses: sonarsource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_URL }}
+        with:
+          args: >
+            -Dsonar.sonar.sources=./src 
+            -Dsonar.qualitygate.wait=true
+            -Dsonar.projectBaseDir=.
+            -Dsonar.verbose=false
+            -Dsonar.projectKey=${{ secrets.SONAR_PROJECT }}
+            -Dsonar.sonar.sourceEncoding=UTF-8
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
+            -Dsonar.coverage.exclusions=**/storage/**,**/**.config.js,**/*.test.tsx,**/icons/**

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -43,4 +43,4 @@ jobs:
             -Dsonar.projectKey=${{ secrets.SONAR_PROJECT }}
             -Dsonar.sonar.sourceEncoding=UTF-8
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
-            -Dsonar.coverage.exclusions=**/storage/**,**/**.config.js,**/*.test.tsx,**/icons/**
+            -Dsonar.coverage.exclusions=**/storage/**,**/**.config.js,**/*.test.tsx,**/icons/**,**/docs/**,**/cli/**,**/__mocks__/**

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -11,9 +11,6 @@ on:
       - qa
       - development
 
-env:
-  SONAR_PROJECT: myapp-delete
-
 jobs:
   sonar:
     runs-on: ubuntu-latest

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -43,4 +43,4 @@ jobs:
             -Dsonar.projectKey=${{ secrets.SONAR_PROJECT }}
             -Dsonar.sonar.sourceEncoding=UTF-8
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
-            -Dsonar.coverage.exclusions=**/storage/**,**/**.config.js,**/*.test.tsx,**/icons/**,**/docs/**,**/cli/**,**/__mocks__/**
+            -Dsonar.coverage.exclusions=**/storage/**,**/**.config.js,**/*.test.tsx,**/icons/**,**/docs/**,**/cli/**,**/__mocks__/**,**/android/**,**/ios/**

--- a/README-project.md
+++ b/README-project.md
@@ -37,6 +37,10 @@ To run the app on Android
 pnpm android
 ```
 
+### SonarQube setup
+
+SonarQube is an open-source platform for continuous inspection of code quality. It performs automatic reviews to detect bugs, code smells, and security vulnerabilities. Rootstrap has a SonarQube instance to improve the quality of the software we develop. On each PR, a GitHub Action is triggered to perform the analysis. To set up SonarQube correctly, you need to add the `SONAR_TOKEN`, `SONAR_URL`, and `SONAR_PROJECT` secrets to the repository. Additionally, you must select the quality gate named `ReactNativeTemplate` for your project on SonarQube. In case you're using this project outside Rootstrap and you're not planning to use SonarQube the sonar scanner [workflow](.github/workflows/sonar.yml) should be deleted.
+
 ## ✍️ Documentation
 
 - [Rules and Conventions](https://starter.obytes.com/getting-started/rules-and-conventions/)

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,11 @@ module.exports = {
   transformIgnorePatterns: [
     `node_modules/(?!(?:.pnpm/)?((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg))`,
   ],
-  coverageReporters: ['json-summary', ['text', { file: 'coverage.txt' }]],
+  coverageReporters: [
+    'json-summary',
+    ['text', { file: 'coverage.txt' }],
+    'lcov',
+  ],
   reporters: [
     'default',
     ['github-actions', { silent: false }],


### PR DESCRIPTION
<!---
❌❌❌
WARNING!!!
Make sure the base repository is `rootstrap/react-native-template` BEFORE creating the Pull Request.
❌❌❌
-->

## What does this do?

Add sonar scanner github action so that it's triggered on every pull request and push to gitflow branches.

## Why did you do this?

At Rootstrap we use SonarQuube for continuous inspection of code quality, detect bugs, code smells, and security vulnerabilities. 

## Who/what does this impact?

Github actions

## How did you test this?

This action will run on this PR and the status of the check will be shown.
