### PR TITLE
feat(cli): use our repository as template

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -40,4 +40,4 @@ jobs:
             -Dsonar.projectKey=${{ secrets.SONAR_PROJECT }}
             -Dsonar.sonar.sourceEncoding=UTF-8
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
-            -Dsonar.coverage.exclusions=**/storage/**,**/**.config.js,**/*.test.tsx,**/icons/**,**/docs/**,**/cli/**,**/__mocks__/**,**/android/**,**/ios/**
+            -Dsonar.coverage.exclusions=**/storage/**,**/**.config.js,**/*.test.tsx,**/icons/**,**/docs/**,**/cli/**,**/__mocks__/**,**/android/**,**/ios/**,env.js

--- a/cli/clone-repo.js
+++ b/cli/clone-repo.js
@@ -1,10 +1,12 @@
 const { runCommand } = require('./utils.js');
 const { consola } = require('consola');
 
+const repository = "rootstrap/react-native-template";
+
 const getLatestRelease = async () => {
   try {
     const repoData = await fetch(
-      'https://api.github.com/repos/obytes/react-native-template-obytes/releases/latest'
+      `https://api.github.com/repos/${repository}/releases/latest`
     );
     const releaseData = await repoData.json();
     return releaseData.tag_name || 'master';
@@ -19,13 +21,13 @@ const getLatestRelease = async () => {
 const cloneLastTemplateRelease = async (projectName) => {
   consola.start('Extracting last release number 👀');
   const latest_release = await getLatestRelease();
-  consola.info(`Using Obytes starter ${latest_release}`);
+  consola.info(`Using Rootstrap's Template ${latest_release}`);
 
-  // create a new project based on obytes template
-  const cloneStarter = `git clone -b ${latest_release} --depth=1   https://github.com/obytes/react-native-template-obytes.git ${projectName}`;
+  // create a new project based on Rootstrap template
+  const cloneStarter = `git clone -b ${latest_release} --depth=1 https://github.com/${repository}.git ${projectName}`;
   await runCommand(cloneStarter, {
-    loading: 'Extracting the starter template...',
-    success: 'Starter extracted successfully',
+    loading: 'Extracting the template...',
+    success: 'Template extracted successfully',
     error: 'Failed to download and extract template',
   });
 };

--- a/cli/index.js
+++ b/cli/index.js
@@ -4,15 +4,17 @@ const { consola } = require('consola');
 const { showMoreDetails } = require('./utils.js');
 const { cloneLastTemplateRelease } = require('./clone-repo.js');
 const { setupProject, installDeps } = require('./setup-project.js');
+const pkg = require('./package.json');
 
-const createObytesApp = async () => {
-  consola.box('Obytes Starter\nPerfect React Native App Kickstart 🚀!');
+const { name: packageName } = pkg;
+const createRootstrapApp = async () => {
+  consola.box("Rootstrap's React Native Template\nPerfect React Native App Kickstart 🚀!");
   // get project name from command line
   const projectName = process.argv[2];
   // check if project name is provided
   if (!projectName) {
     consola.error(
-      'Please provide a name for your project: `npx create-rootstrap-rn-app@latest <project-name>`'
+      `Please provide a name for your project: \`npx ${packageName}@latest <project-name>\``
     );
     process.exit(1);
   }
@@ -29,4 +31,4 @@ const createObytesApp = async () => {
   showMoreDetails(projectName);
 };
 
-createObytesApp();
+createRootstrapApp();

--- a/cli/setup-project.js
+++ b/cli/setup-project.js
@@ -9,7 +9,7 @@ const initGit = async (projectName) => {
 
 const installDeps = async (projectName) => {
   await runCommand(`cd ${projectName} && pnpm install`, {
-    loading: 'Installing  project dependencies',
+    loading: 'Installing project dependencies',
     success: 'Dependencies installed',
     error: 'Failed to install dependencies, Make sure you have pnpm installed',
   });
@@ -55,9 +55,9 @@ const updateProjectConfig = async (projectName) => {
     encoding: 'utf-8',
   });
   const replaced = contents
-    .replace(/ObytesApp/gi, projectName)
-    .replace(/com.obytes/gi, `com.${projectName.toLowerCase()}`)
-    .replace(/obytes/gi, 'expo-owner');
+    .replace(/RootstrapApp/gi, projectName)
+    .replace(/com.rootstrap/gi, `com.${projectName.toLowerCase()}`)
+    .replace(/rootstrap/gi, 'expo-owner');
 
   fs.writeFileSync(configPath, replaced, { spaces: 2 });
   const readmeFilePath = path.join(

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -33,9 +33,9 @@ const showMoreDetails = (projectName) => {
     'Your project is ready to go! \n\n\n',
     '🚀 To get started, run the following commands: \n\n',
     `   \`cd ${projectName}\` \n`,
-    '   IOS     :  `pnpm ios` \n',
+    '   iOS     :  `pnpm ios` \n',
     '   Android :  `pnpm android` \n\n',
-    '📚 Starter Documentation: https://starter.obytes.com'
+    '📚 Template Documentation: https://rootstrap.github.io/react-native-template'
   );
 };
 

--- a/env.js
+++ b/env.js
@@ -28,17 +28,17 @@ require('dotenv').config({
  * Such as: bundle id, package name, app name.
  *
  * You can add them to the .env file but we think it's better to keep them here as as we use prefix to generate this values based on the APP_ENV
- * for example: if the APP_ENV is staging, the bundle id will be com.obytes.staging
+ * for example: if the APP_ENV is staging, the bundle id will be com.rootstrap.staging
  */
 
 // TODO: Replace these values with your own
 
-const BUNDLE_ID = 'com.rs.mobile'; // ios bundle id
-const PACKAGE = 'com.rs.mobile'; // android package name
-const NAME = 'react-native-template'; // app name
-const EXPO_ACCOUNT_OWNER = 'rsdevs'; // expo account owner
+const BUNDLE_ID = 'com.rootstrap'; // ios bundle id
+const PACKAGE = 'com.rootstrap'; // android package name
+const NAME = 'RootstrapApp'; // app name
+const EXPO_ACCOUNT_OWNER = 'rootstrap'; // expo account owner
 const EAS_PROJECT_ID = 'c3e1075b-6fe7-4686-aa49-35b46a229044'; // eas project id
-const SCHEME = 'react-native-template'; // app scheme
+const SCHEME = 'rootstrapApp'; // app scheme
 
 /**
  * We declare a function withEnvSuffix that will add a suffix to the variable name based on the APP_ENV


### PR DESCRIPTION
## What does this do?

- Use our repository as template when executing the CLI.
- Change some wordings like "Starter" to "Template", and change references from Obytes to Rootstrap.
- Refactor some code to reuse strings, or read them from the `package.json` file.
- TODO: The README file from the CLI project still needs to be changed.

## Why did you do this?

- To start testing new changes from our template into new projects started from our CLI.

## Who/what does this impact?

N/A

## How did you test this?

Running locally:
```shell
cd cli
./index.js MyTestApp
```

Then checking that the created project is consistent with what the CLI do.
