### PR TITLE
chore(cli): rename CLI to create-rootstrap-rn-app

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,11 +24,20 @@
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "astro-build.astro-vscode"
   },
-  "cSpell.words": ["Flashlist", "Lato"],
-  "i18n-ally.localesPaths": ["src/translations/"],
+  "cSpell.words": [
+    "Flashlist",
+    "Lato",
+    "rootstrap"
+  ],
+  "i18n-ally.localesPaths": [
+    "src/translations/"
+  ],
   "i18n-ally.keystyle": "nested",
   "i18n-ally.disabled": false, // make sure to disable i18n-ally in your global setting and only enable it for such projects
   "tailwindCSS.experimental.classRegex": [
-    ["tv\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
-  ]
+    [
+      "tv\\(([^)]*)\\)",
+      "[\"'`]([^\"'`]*).*?[\"'`]"
+    ]
+  ],
 }

--- a/cli/README.md
+++ b/cli/README.md
@@ -13,7 +13,7 @@
 # 🚀 Quick start
 
 ```sh
-npx create-obytes-app@latest MyApp
+npx create-rootstrap-rn-app@latest MyApp
 
 ```
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -12,7 +12,7 @@ const createObytesApp = async () => {
   // check if project name is provided
   if (!projectName) {
     consola.error(
-      'Please provide a name for your project: `npx create-obytes-app@latest <project-name>`'
+      'Please provide a name for your project: `npx create-rootstrap-rn-app@latest <project-name>`'
     );
     process.exit(1);
   }

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "create-obytes-app",
-  "version": "1.7.1",
-  "description": "Obytes expo starter cli",
-  "homepage": "https://github.com/obytes/react-native-template-obytes",
+  "name": "create-rootstrap-rn-app",
+  "version": "1.0.0",
+  "description": "Rootstrap expo starter cli",
+  "homepage": "https://github.com/rootstrap/react-native-template",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/obytes/react-native-template-obytes.git"
+    "url": "git+https://github.com/rootstrap/react-native-template.git"
   },
   "main": "index.js",
   "scripts": {
     "start": "node ."
   },
   "bin": {
-    "create-obytes-app": "index.js"
+    "create-rootstrap-rn-app": "index.js"
   },
   "files": [
     "index.js",
@@ -33,6 +33,7 @@
     "react-native-boilerplate",
     "expo-boilerplate",
     "cli",
-    "obytes"
+    "obytes",
+    "rootstrap"
   ]
 }

--- a/cli/pnpm-lock.yaml
+++ b/cli/pnpm-lock.yaml
@@ -1,46 +1,56 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  consola:
-    specifier: ^3.2.3
-    version: 3.2.3
-  fs-extra:
-    specifier: ^10.1.0
-    version: 10.1.0
+importers:
+
+  .:
+    dependencies:
+      consola:
+        specifier: ^3.2.3
+        version: 3.2.3
+      fs-extra:
+        specifier: ^10.1.0
+        version: 10.1.0
 
 packages:
 
-  /consola@3.2.3:
+  consola@3.2.3:
     resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
     engines: {node: ^14.18.0 || >=16.10.0}
-    dev: false
 
-  /fs-extra@10.1.0:
+  fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
+
+  graceful-fs@4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
+
+  jsonfile@6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+
+  universalify@2.0.0:
+    resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
+    engines: {node: '>= 10.0.0'}
+
+snapshots:
+
+  consola@3.2.3: {}
+
+  fs-extra@10.1.0:
     dependencies:
       graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
-    dev: false
 
-  /graceful-fs@4.2.10:
-    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
-    dev: false
+  graceful-fs@4.2.10: {}
 
-  /jsonfile@6.1.0:
-    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+  jsonfile@6.1.0:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
       graceful-fs: 4.2.10
-    dev: false
 
-  /universalify@2.0.0:
-    resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
-    engines: {node: '>= 10.0.0'}
-    dev: false
+  universalify@2.0.0: {}

--- a/docs/src/content/docs/getting-started/create-new-app.md
+++ b/docs/src/content/docs/getting-started/create-new-app.md
@@ -27,10 +27,10 @@ First make sure you have `pnpm` installed on your machine, if not you can instal
 npm install -g pnpm
 ```
 
-Start your project using `create-obytes-app` command:
+Start your project using `create-rootstrap-rn-app` command:
 
 ```bash
-npx create-obytes-app@latest MyApp
+npx create-rootstrap-rn-app@latest MyApp
 ```
 
 The command will create an expo app named `MyApp` and install all the dependencies added by the starter.
@@ -46,7 +46,7 @@ The name must satisfy the following rules:
 - It must have at least two segments (one or more dots).
 - Each segment must start with a letter.
 - All characters must be alphanumeric or an underscore [a-zA-Z0-9_].
-:::
+  :::
 
 ## Open Project on VS Code
 


### PR DESCRIPTION
## What does this do?

This PR renames the `create-obytes-app` package from the `cli` directory to `create-rootstrap-rn-app`. It also changes some metadata in the `package.json` and sets the version to `1.0.0`.

## Why did you do this?

To be able to publish our own version of the CLI in npm registry.

## Who/what does this impact?

This change doesn't affect any project, as the CLI isn't published yet.

## How did you test this?

Still untested. I'm going to manually publish the 1.0.0 version of the CLI and check if it works properly.
**Edit:** cli is now published [here](https://www.npmjs.com/package/create-rootstrap-rn-app) 🙌 