### PR TITLE
feat(cli): add GH action for publishing new version

### DIFF
--- a/.github/workflows/new-cli-version.yml
+++ b/.github/workflows/new-cli-version.yml
@@ -1,0 +1,93 @@
+# 🔗 Links:
+# Source file: https://github.com/rootstrap/react-native-template/blob/master/.github/workflows/new-cli-version.yml
+
+# ✍️ Description:
+# This workflow is used to create a new version of the CLI and publish it to the npm registry.
+# As this workflow will push code to the repo, we set up GitHub Bot as a Git user.
+# This Workflow need to be triggered manually from the Actions tab in the repo.
+#         1. Choose your release type (patch, minor, major)
+#         2. The workflow will run the np-release script which runs the following steps:
+#             - Bump the version in package.json based on the release type using np
+#             - Build & publish the CLI to the npm registry
+#
+
+# 🚨 GITHUB SECRETS REQUIRED:
+#         - GH_TOKEN: A GitHub token with write repo access.
+#           You can generate one from here: https://docs.github.com/en/enterprise-server@3.6/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+#           make sure to add it to the repo secrets with the name GH_TOKEN
+
+name: New CLI Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        type: choice
+        description: 'Release type (one of): patch, minor, major'
+        required: true
+        default: 'patch'
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  release:
+    name: Create New Version and push new tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: 🔍 GH_TOKEN
+        if: env.GH_TOKEN == ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "GH_TOKEN=${GITHUB_TOKEN}" >> $GITHUB_ENV
+
+      - name: 📦 Checkout project repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: 📝 Git User Setup
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: 📦 Setup Node + PNPM
+        uses: ./.github/actions/setup-node-pnpm-install
+
+      - name: Install CLI dependencies
+        run: |
+          cd cli
+          pnpm install --frozen-lockfile
+
+      - name: Bump release version
+        run: |
+          cd cli
+          echo "NEW_VERSION=$(npm --no-git-tag-version version $RELEASE_TYPE)" >> $GITHUB_ENV
+          echo "RELEASE_TAG=latest" >> $GITHUB_ENV
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.release-type }}
+
+      - name: Commit package.json changes
+        run: |
+          git add "cli/package.json"
+          git commit -m "build(cli): release ${{ env.NEW_VERSION }}"
+
+      - name: Set publishing config
+        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+      - name: Publish
+        run: |
+          cd cli
+          pnpm publish --verbose --tag ${{ env.RELEASE_TAG }}
+
+      - name: Push changes to repository
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push origin && git push --tags


### PR DESCRIPTION
## What does this do?

This PR adds a new GH Action to be used to build & publish a new version of the CLI.

## Why did you do this?

- To avoid having to manually publish a new version from a local machine.

## Who/what does this impact?

N/A

## How did you test this?

https://github.com/rootstrap/react-native-template/actions/runs/10223286450/job/28289351702
