### PR TITLE
chore(ci): run lint, test and type check on every pull request

### DIFF
--- a/.github/workflows/lint-ts.yml
+++ b/.github/workflows/lint-ts.yml
@@ -3,7 +3,7 @@
 
 # ✍️ Description:
 # This action is used to run eslint checks
-# Runs on pull requests and pushes to  the main/master branches
+# Runs on any pull request, and also when pushing to main/master
 # Based on the event type:
 #   - If it's a pull request, it will run eslint, then add the check to the PR as well as annotate the code with the errors and warnings.
 #   - If it's a push to main/master, it will run the type checking and fail if there are any errors.
@@ -16,7 +16,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    types: [opened, synchronize]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@
 
 # ✍️ Description:
 # This action is used to run unit tests
-# Runs on pull requests and pushes to  the main/master branches
+# Runs on any pull request, and also when pushing to main/master
 # Based on the event type:
 #   - If it's a pull request, it will run the tests and post a comment with coverage details.
 #   - If it's a push to main/master, it will run the tests and add the check to the commit.
@@ -16,7 +16,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    types: [opened, synchronize]
 
 jobs:
   test:

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -3,7 +3,7 @@
 
 # ✍️ Description:
 # This action is used to run the type-check on the project.
-# Runs on pull requests and pushes to  the main/master branches
+# Runs on any pull request, and also when pushing to main/master
 # Based on the event type:
 #   - If it's a pull request, it will run type checking, then add the check to the PR as well as annotate the code with the errors using reviewdog.
 #   - If it's a push to main/master, it will run the type checking and fail if there are any errors.
@@ -16,7 +16,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    types: [opened, synchronize]
 
 jobs:
   type-check:


### PR DESCRIPTION
<!---
❌❌❌
WARNING!!!
Make sure the base repository is `rootstrap/react-native-template` BEFORE creating the Pull Request.
❌❌❌
-->

## What does this do?

This PR changes the Lint, Test and Type Check GH Actions so they always run on any pull request, and not only the ones having main/master as base branch.

## Why did you do this?

Because in some scenarios we have PRs for branches pointing to other branches than main/master and it's nice if we can start running checks on them.

## Who/what does this impact?

Template maintainers.

## How did you test this?

Still untested. Will edit this comment with more information after these changes are applied.
