### PR TITLE
feat: add action for checking upstream for changes

### DIFF
--- a/.github/workflows/upstream-to-pr.yml
+++ b/.github/workflows/upstream-to-pr.yml
@@ -1,0 +1,22 @@
+name: ⤵️ Check upstream for changes
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
+
+      - uses: fopina/upstream-to-pr@v1
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          upstream-repository: https://github.com/obytes/react-native-template-obytes
+          upstream-branch: master

--- a/cli/clone-repo.js
+++ b/cli/clone-repo.js
@@ -1,12 +1,10 @@
-const { runCommand } = require('./utils.js');
+const { runCommand, TEMPLATE_REPOSITORY } = require('./utils.js');
 const { consola } = require('consola');
-
-const repository = "rootstrap/react-native-template";
 
 const getLatestRelease = async () => {
   try {
     const repoData = await fetch(
-      `https://api.github.com/repos/${repository}/releases/latest`
+      `https://api.github.com/repos/${TEMPLATE_REPOSITORY}/releases/latest`
     );
     const releaseData = await repoData.json();
     return releaseData.tag_name || 'master';
@@ -24,7 +22,7 @@ const cloneLastTemplateRelease = async (projectName) => {
   consola.info(`Using Rootstrap's Template ${latest_release}`);
 
   // create a new project based on Rootstrap template
-  const cloneStarter = `git clone -b ${latest_release} --depth=1 https://github.com/${repository}.git ${projectName}`;
+  const cloneStarter = `git clone -b ${latest_release} --depth=1 https://github.com/${TEMPLATE_REPOSITORY}.git ${projectName}`;
   await runCommand(cloneStarter, {
     loading: 'Extracting the template...',
     success: 'Template extracted successfully',

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -2,6 +2,9 @@
 const { exec } = require('child_process');
 const { consola } = require('consola');
 
+const UPSTREAM_REPOSITORY = "obytes/react-native-template-obytes";
+const TEMPLATE_REPOSITORY = "rootstrap/react-native-template";
+
 const execShellCommand = (cmd) => {
   return new Promise((resolve, reject) => {
     exec(cmd, (error, stdout, stderr) => {
@@ -43,4 +46,6 @@ module.exports = {
   runCommand,
   showMoreDetails,
   execShellCommand,
+  UPSTREAM_REPOSITORY,
+  TEMPLATE_REPOSITORY,
 };


### PR DESCRIPTION
## What does this do?

- This PR adds a new GitHub Action to check for upstream (obytes) changes and it creates a new branch and a PR with those changes. The action will automatically be triggered daily. It also allows for manual/API triggered checks (workflow_dispatch).
- It also modifies the `cli` app so new projects created with the latest `cli` version will also have this action, which will check if Rootstrap's Template repository has new changes to be merged to their project.

## Why did you do this?

To automate, notify and control what changes we want to merge from the upstream repository (Obytes) to our template.

## Who/what does this impact?

- **Template Maintainers** because, starting from now, new PRs will be automatically created and they'll have the responsibility to review them, decide and debate which changes from Obytes we want to include in our Template and fix possible merge conflicts.
- **Developers** using our Template in their projects.

## How did you test this?

https://github.com/rootstrap/react-native-template/pull/34
