### PR TITLE
chore: remove environment variables from expo-doctor workflow

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,4 @@
-API_URL=https://dummyjson.com/
-
-## TODO: add the variable to your  CI and remove it from here, not recommended setting sensitive values on your git repo
-SECRET_KEY=my-secret-key
-VAR_NUMBER=10 # this is a number variable
-VAR_BOOL=true # this is a boolean variable
+API_URL=
+VAR_NUMBER=
+VAR_BOOL=
+SECRET_KEY=

--- a/.github/workflows/expo-doctor.yml
+++ b/.github/workflows/expo-doctor.yml
@@ -28,13 +28,6 @@ jobs:
     name: Expo Doctor (expo)
     runs-on: ubuntu-latest
 
-    env:
-      # Add your other environment variables here, e.g.:
-      API_URL: https://dummyjson.com/
-      SECRET_KEY: my-secret-key
-      VAR_NUMBER: 10
-      VAR_BOOL: true
-
     steps:
       - name: 📦 Checkout project repo
         uses: actions/checkout@v3
@@ -43,9 +36,6 @@ jobs:
 
       - name: 📦 Setup Node + PNPM + install deps
         uses: ./.github/actions/setup-node-pnpm-install
-
-      - name: Run prebuild
-        run: pnpm run prebuild ## we only need to run this to generate the badged icon in `.expo` folder
 
       - name: 🚑 Run Doctor Checks
         run: rm -rf ios android && pnpm run doctor ## apprently the new update of expo will break if you already have ios and android folders in your project as they will show up a eas warning


### PR DESCRIPTION
## What does this do?

- Remove example values from `.env.sample` to minimize mistakes.
- Remove environment variables from `expo-doctor.yml` workflow.
- Remove `prebuild` step from `expo-doctor.yml` workflow.
- Add more type-checking to `env.js` file.
- Add `parseString`, `parseNumber` and `parseBoolean` utility functions.

## Why did you do this?

To avoid having to define dummy values to all environment variables in order to run expo doctor.

## Who/what does this impact?

Devs using the template.

## How did you test this?

WIP
