### PR TITLE
build(docs): fix docs project not building

### DIFF
--- a/docs/src/content/docs/ci-cd/app-releasing-process.mdx
+++ b/docs/src/content/docs/ci-cd/app-releasing-process.mdx
@@ -59,8 +59,6 @@ The starter comes with a set of GitHub workflows that use EXPO EAS to build and 
 
 - `new-app-version.yml` : A workflow that run `app-release` script in order to update the app version and push a new tag to GitHub.
 
-- `new-github-release.yml` : A workflow that is triggered whenever a new tag is pushed to GitHub. It will create a new GitHub release based on the tag name with the correct changelog.
-
 - `eas-build-qa.yml` : A workflow that is triggered whenever a new release is created on GitHub. It will build the app using EXPO EAS and based on the config it will distribute.
 
 - `eas-build-prod.yml` : A workflow that is triggered manually whenever we want to push a new release to the App Store and Google Play. It will build the app using EXPO EAS and based on the config it will distribute.

--- a/docs/src/content/docs/ci-cd/workflows-references.mdx
+++ b/docs/src/content/docs/ci-cd/workflows-references.mdx
@@ -32,7 +32,7 @@ All actions are located in the `.github/actions` folder, and here is the complet
 
 ### ⚙️ EAS Build
 
-<CodeBlock file=".github/actions/eas-build/action.yml" />
+<CodeBlock file=".github/workflows/eas-build.yml" />
 
 ## Workflows
 
@@ -58,19 +58,7 @@ All actions are located in the `.github/actions` folder, and here is the complet
 
 ### ⚙️ New App Version
 
-<CodeBlock file=".github/workflows/new-app-version.yml" />
-
-### ⚙️ New Github Release
-
-<CodeBlock file=".github/workflows/new-github-release.yml" />
-
-### ⚙️ EAS Build QA
-
-<CodeBlock file=".github/workflows/eas-build-qa.yml" />
-
-### ⚙️ EAS Build Prod
-
-<CodeBlock file=".github/workflows/eas-build-prod.yml" />
+<CodeBlock file=".github/workflows/new-template-version.yml" />
 
 ### ⚙️ E2E Test for Android
 


### PR DESCRIPTION
## What does this do?

Fix docs project not building.

## Why did you do this?

Because the docs project deployment was failing. See [logs](https://github.com/rootstrap/react-native-template/actions/runs/10692121403/job/29639956077).

## Who/what does this impact?

Docs users.

## How did you test this?

1. Running `pnpm run build` in `docs` directory and veryfing that the build was failing locally.
2. Fixing the issues locally.
3. Running `pnpm run build` again and verifying that it does build successfully.