### PR TITLE
fix: fix deploy docs to github pages failing because of wrong import paths

### DIFF
--- a/docs/src/content/docs/ci-cd/workflows-references.mdx
+++ b/docs/src/content/docs/ci-cd/workflows-references.mdx
@@ -32,7 +32,7 @@ All actions are located in the `.github/actions` folder, and here is the complet
 
 ### ⚙️ EAS Build
 
-<CodeBlock file=".github/actions/eas-build/action.yml" />
+<CodeBlock file=".github/workflows/eas-build.yml" />
 
 ## Workflows
 
@@ -58,7 +58,7 @@ All actions are located in the `.github/actions` folder, and here is the complet
 
 ### ⚙️ New App Version
 
-<CodeBlock file=".github/workflows/new-app-version.yml" />
+<CodeBlock file=".github/workflows/new-template-version.yml" />
 
 ### ⚙️ New Github Release
 


### PR DESCRIPTION
## What does this do?
_This PR fixes bad imports in `docs/content/docs/ci/cd/workflows-references.mdx`._

## Why did you do this?
_Currently the Github action is failing for new deployments._

## How did you test this?
_Run the `deploy-docs.yml` action._
