### PR TITLE
fix: fix github stars point to rs repo

### DIFF
--- a/docs/src/components/GithubStar.astro
+++ b/docs/src/components/GithubStar.astro
@@ -72,6 +72,7 @@ import { Icon } from '@astrojs/starlight/components';
     color: var(--sl-color-accent-high);
   }
   .star-count{
+    text-align: right;
     font-weight: 700;
     min-width: 20px;
     color: transparent;
@@ -90,7 +91,7 @@ import { Icon } from '@astrojs/starlight/components';
     if (starCountElement) {
       starCountElement.classList.add("spinner");
 
-      fetch("https://api.github.com/repos/obytes/react-native-template-obytes")
+      fetch("https://api.github.com/repos/rootstrap/react-native-template")
         .then((response) => response.json())
         .then((data) => {
           starCountElement.classList.remove("spinner");
@@ -108,7 +109,7 @@ import { Icon } from '@astrojs/starlight/components';
 <a
   target="_blank"
   rel="noreferrer noopener"
-  href="https://github.com/obytes/react-native-template-obytes"
+  href="https://github.com/rootstrap/react-native-template"
   class="link">
   <span
     id="star-count"


### PR DESCRIPTION
## What does this do?
Fixes the repo the component `GithubStar.astro` to fetch stars from the Rootstrap Template repo.
