### PR TITLE
docs: add instructions to upload envfiles to eas secrets

### DIFF
--- a/EAS.md
+++ b/EAS.md
@@ -6,6 +6,13 @@ To be able to use Expo Application Services to upload your app to App Store and 
 
 To be able to trigger the eas-build github action you will have to add the `EXPO_TOKEN` secret to the repo settings. This secret is a required access token for your Expo account. https://expo.dev/settings/access-tokens
 
+You will also have to upload your envfiles to EAS secrets:
+
+`eas secret:create --scope project --name ENVIRONMENT_FILE_PRODUCTION --value .env.production --type file`
+`eas secret:create --scope project --name ENVIRONMENT_FILE_STAGING --value .env.staging --type file`
+
+Each one per environment you'll want to build, it's on [env.js](env.js) that the process looks for the right envfile depending on where the build is being run and the chosen environment.
+
 ### Submit to Google Play Store
 
 The first submission of the app needs to be performed manually. Learn more: https://expo.fyi/first-android-submission. Only after having a valid version submitted you can submit automatically using EAS.


### PR DESCRIPTION
<!---
❌❌❌
WARNING!!!
Make sure the base repository is `rootstrap/react-native-template` BEFORE creating the Pull Request.
❌❌❌
-->

## What does this do?

Add one instruction to the EAS configuration docs about adding envfiles to eas secrets

## Why did you do this?
There was a missing step in the docs

## Who/what does this impact?
Docs and dev experience

## How did you test this?

Manually by running GHA to build EAS