### PR TITLE
refactor(cli): move file operations to ProjectFilesManager class

### DIFF
--- a/cli/clone-repo.js
+++ b/cli/clone-repo.js
@@ -16,7 +16,7 @@ const getLatestRelease = async () => {
   }
 };
 
-const cloneLastTemplateRelease = async (projectName) => {
+const cloneLatestTemplateRelease = async (projectName) => {
   consola.start('Extracting last release number 👀');
   const latest_release = await getLatestRelease();
   consola.info(`Using Rootstrap's Template ${latest_release}`);
@@ -31,5 +31,5 @@ const cloneLastTemplateRelease = async (projectName) => {
 };
 
 module.exports = {
-  cloneLastTemplateRelease,
+  cloneLatestTemplateRelease,
 };

--- a/cli/index.js
+++ b/cli/index.js
@@ -2,8 +2,8 @@
 
 const { consola } = require('consola');
 const { showMoreDetails } = require('./utils.js');
-const { cloneLastTemplateRelease } = require('./clone-repo.js');
-const { setupProject, installDeps } = require('./setup-project.js');
+const { cloneLatestTemplateRelease } = require('./clone-repo.js');
+const { setupProject, installDependencies } = require('./setup-project.js');
 const pkg = require('./package.json');
 
 const { name: packageName } = pkg;
@@ -18,14 +18,14 @@ const createRootstrapApp = async () => {
     );
     process.exit(1);
   }
-  // clone the last release of the template from github
-  await cloneLastTemplateRelease(projectName);
+  // clone the latest release of the template from github
+  await cloneLatestTemplateRelease(projectName);
 
-  // setup the project: remove unnecessary files, update package.json infos, name and  set version to 0.0.1 + add initial version to osMetadata
+  // setup the project
   await setupProject(projectName);
 
   // install project dependencies using pnpm
-  await installDeps(projectName);
+  await installDependencies(projectName);
 
   // show instructions to run the project + link to the documentation
   showMoreDetails(projectName);

--- a/cli/project-files-manager.js
+++ b/cli/project-files-manager.js
@@ -1,0 +1,102 @@
+const fs = require('fs-extra');
+const path = require('path');
+
+class ProjectFilesManager {
+  #projectName;
+
+  constructor(
+    /**
+     * @type {string}
+     */
+    projectName
+  ) {
+    this.#projectName = projectName;
+  }
+
+  static withProjectName(
+    /**
+     * @type {string}
+     */
+    projectName
+  ) {
+    return new this(projectName);
+  }
+
+  getAbsoluteFilePath(
+    /**
+     * A file path relative to project's root path
+     * @type {string}
+     */
+    relativeFilePath
+  ) {
+    return path.join(process.cwd(), `${this.#projectName}/${relativeFilePath}`);
+  }
+
+  removeFiles(
+    /**
+     * An array of file paths relative to project's root path
+     * @type {Array<string>}
+     */
+    files
+  ) {
+    files.forEach((fileName) => {
+      const absoluteFilePath = this.getAbsoluteFilePath(fileName);
+
+      fs.removeSync(absoluteFilePath);
+    });
+  }
+
+  renameFiles(
+    /**
+     * An array of objects containing the old and the new file names
+     * relative to project's root path
+     *
+     * @type {Array<{
+     *   oldFileName: string;
+     *   newFileName: string;
+     *  }>}
+     */
+    files
+  ) {
+    files.forEach(({ oldFileName, newFileName }) => {
+      const oldAbsoluteFilePath = this.getAbsoluteFilePath(oldFileName);
+      const newAbsoluteFilePath = this.getAbsoluteFilePath(newFileName);
+
+      fs.renameSync(oldAbsoluteFilePath, newAbsoluteFilePath);
+    });
+  }
+
+  replaceFilesContent(
+    /**
+     * An array of objects containing the file name relative to project's
+     * root path and the replacement patterns to be applied
+     *
+     * @type {Array<{
+     *  fileName: string;
+     *  replacements: Array<{
+     *    searchValue: string;
+     *    replaceValue: string;
+     *  }>
+     * }>}
+     */
+    files
+  ) {
+    files.forEach(({ fileName, replacements }) => {
+      const absoluteFilePath = this.getAbsoluteFilePath(fileName);
+
+      const contents = fs.readFileSync(absoluteFilePath, {
+        encoding: 'utf-8',
+      });
+
+      let replaced = contents;
+
+      replacements.forEach(({ searchValue, replaceValue }) => {
+        replaced = replaced.replace(searchValue, replaceValue);
+      });
+
+      fs.writeFileSync(absoluteFilePath, replaced, { spaces: 2 });
+    });
+  }
+}
+
+module.exports = ProjectFilesManager;

--- a/cli/setup-project.js
+++ b/cli/setup-project.js
@@ -6,13 +6,18 @@ const {
 } = require('./utils.js');
 const { consola } = require('consola');
 const fs = require('fs-extra');
-const path = require('path');
+const ProjectFilesManager = require('./project-files-manager.js');
 
-const initGit = async (projectName) => {
+/**
+ * @type {ProjectFilesManager}
+ */
+let projectFilesManager;
+
+const initializeProjectRepository = async (projectName) => {
   await execShellCommand(`cd ${projectName} && git init && cd ..`);
 };
 
-const installDeps = async (projectName) => {
+const installDependencies = async (projectName) => {
   await runCommand(`cd ${projectName} && pnpm install`, {
     loading: 'Installing project dependencies',
     success: 'Dependencies installed',
@@ -20,21 +25,15 @@ const installDeps = async (projectName) => {
   });
 };
 
-// remove unnecessary files and directories
-const removeFiles = (projectName) => {
-  const FILES_TO_REMOVE = ['.git', 'README.md', 'docs', 'cli', 'LICENSE'];
-
-  FILES_TO_REMOVE.forEach((file) => {
-    fs.removeSync(path.join(process.cwd(), `${projectName}/${file}`));
-  });
+const removeUnrelatedFiles = () => {
+  projectFilesManager.removeFiles(['.git', 'README.md', 'docs', 'cli', 'LICENSE']);
 };
 
 // Update package.json infos, name and  set version to 0.0.1 + add initial version to osMetadata
-const updatePackageInfos = async (projectName) => {
-  const packageJsonPath = path.join(
-    process.cwd(),
-    `${projectName}/package.json`
-  );
+const updatePackageJson = async (projectName) => {
+  const packageJsonPath =
+    projectFilesManager.getAbsoluteFilePath('package.json');
+
   const packageJson = fs.readJsonSync(packageJsonPath);
   packageJson.osMetadata = { initVersion: packageJson.version };
   packageJson.version = '0.0.1';
@@ -53,20 +52,30 @@ const updatePackageInfos = async (projectName) => {
 };
 
 const updateProjectConfig = async (projectName) => {
-  const configPath = path.join(process.cwd(), `${projectName}/env.js`);
-  const contents = fs.readFileSync(configPath, {
-    encoding: 'utf-8',
-  });
-  const replaced = contents
-    .replace(/RootstrapApp/gi, projectName)
-    .replace(/com.rootstrap/gi, `com.${projectName.toLowerCase()}`)
-    .replace(/rootstrap/gi, 'expo-owner');
-
-  fs.writeFileSync(configPath, replaced, { spaces: 2 });
+  projectFilesManager.replaceFilesContent([
+    {
+      fileName: 'env.js',
+      replacements: [
+        {
+          searchValue: /RootstrapApp/gi,
+          replaceValue: projectName,
+        },
+        {
+          searchValue: /com.rootstrap/gi,
+          replaceValue: `com.${projectName.toLowerCase()}`,
+        },
+        {
+          searchValue: /rsdevs/gi,
+          replaceValue: 'expo-owner',
+        },
+      ],
+    },
+  ]);
 };
 
 const updateGitHubWorkflows = (projectName) => {
-  const WORKFLOW_FILES = [
+  // Update useful workflows
+  projectFilesManager.replaceFilesContent([
     {
       fileName: '.github/workflows/upstream-to-pr.yml',
       replacements: [
@@ -92,59 +101,43 @@ const updateGitHubWorkflows = (projectName) => {
           replaceValue: 'Run App release',
         },
         {
-          searchValue: /^\s*environment:\s*\n\s*name:\s*template\s*\n\s*url:\s*.+\s*\n/m,
+          searchValue:
+            /^\s*environment:\s*\n\s*name:\s*template\s*\n\s*url:\s*.+\s*\n/m,
           replaceValue: '',
         },
       ],
     },
-  ];
+  ]);
 
-  WORKFLOW_FILES.forEach(({ fileName, replacements }) => {
-    const workflowPath = path.join(process.cwd(), `${projectName}/${fileName}`);
-
-    const contents = fs.readFileSync(workflowPath, {
-      encoding: 'utf-8',
-    });
-
-    let replaced = contents;
-
-    replacements.forEach(({ searchValue, replaceValue }) => {
-      replaced = replaced.replace(searchValue, replaceValue);
-    });
-
-    fs.writeFileSync(workflowPath, replaced, { spaces: 2 });
-  });
-};
-
-const renameFiles = (projectName) => {
-  const FILES_TO_RENAME = [
-    {
-      oldFileName: 'README-project.md',
-      newFileName: 'README.md',
-    },
+  projectFilesManager.renameFiles([
     {
       oldFileName: '.github/workflows/new-template-version.yml',
       newFileName: '.github/workflows/new-app-version.yml',
     },
-  ];
+  ]);
+};
 
-  FILES_TO_RENAME.forEach(({ oldFileName, newFileName }) => {
-    fs.renameSync(
-      path.join(process.cwd(), `${projectName}/${oldFileName}`),
-      path.join(process.cwd(), `${projectName}/${newFileName}`)
-    );
-  });
+const updateProjectReadme = () => {
+  projectFilesManager.renameFiles([
+    {
+      oldFileName: 'README-project.md',
+      newFileName: 'README.md',
+    },
+  ]);
 };
 
 const setupProject = async (projectName) => {
   consola.start(`Clean up and setup your project 🧹`);
+
+  projectFilesManager = ProjectFilesManager.withProjectName(projectName);
+
   try {
-    removeFiles(projectName);
-    await initGit(projectName);
-    updatePackageInfos(projectName);
+    removeUnrelatedFiles();
+    await initializeProjectRepository(projectName);
+    updatePackageJson(projectName);
     updateProjectConfig(projectName);
     updateGitHubWorkflows(projectName);
-    renameFiles(projectName);
+    updateProjectReadme();
     consola.success(`Clean up and setup your project 🧹`);
   } catch (error) {
     consola.error(`Failed to clean up project folder`, error);
@@ -154,5 +147,5 @@ const setupProject = async (projectName) => {
 
 module.exports = {
   setupProject,
-  installDeps,
+  installDependencies,
 };


### PR DESCRIPTION
## What does this do?

Create a `ProjectFilesManager` class to manage common file operations (removing, renaming and replacing files). It includes types annotations.

## Why did you do this?

- To avoid code repetition within CLI functions.
- To centralize common file operations in one place.
- To have a declarative way to execute those common file operations.

## Who/what does this impact?

Developers of the CLI project.

## How did you test this?

I created a new application with the current version of the CLI, without these changes. Then I created another application with this new CLI, and I compared both projects. As this is just a refactor and no new functionality is being implemented, the two projects should and did have the same contents.
