### PR TITLE
fix(cli): remove docs & CLI deploy workflows

### DIFF
--- a/cli/setup-project.js
+++ b/cli/setup-project.js
@@ -26,7 +26,15 @@ const installDependencies = async (projectName) => {
 };
 
 const removeUnrelatedFiles = () => {
-  projectFilesManager.removeFiles(['.git', 'README.md', 'docs', 'cli', 'LICENSE']);
+  projectFilesManager.removeFiles([
+    '.git',
+    'README.md',
+    'docs',
+    '.github/workflows/deploy-docs.yml',
+    'cli',
+    '.github/workflows/deploy-cli.yml',
+    'LICENSE',
+  ]);
 };
 
 // Update package.json infos, name and  set version to 0.0.1 + add initial version to osMetadata


### PR DESCRIPTION
## What does this do?

Remove `.github/workflows/deploy-cli.yml` and `.github/workflows/deploy-docs.yml` files as part of the project setup process.

## Why did you do this?

Because it doesn't make sense to have those workflows in the context of a project.

## Who/what does this impact?

N/A

## How did you test this?

Locally ran the CLI to create a new project and verifying that the mentioned files were not present.
