### PR TITLE
fix(cli): remove warning from Pull Request Template

### DIFF
--- a/cli/setup-project.js
+++ b/cli/setup-project.js
@@ -123,6 +123,19 @@ const updateGitHubWorkflows = (projectName) => {
       newFileName: '.github/workflows/new-app-version.yml',
     },
   ]);
+
+  // Update Pull Request Template
+  projectFilesManager.replaceFilesContent([
+    {
+      fileName: '.github/PULL_REQUEST_TEMPLATE.md',
+      replacements: [
+        {
+          searchValue: /^[\s\S]*?(?=## What does this do\?)/,
+          replaceValue: '',
+        },
+      ],
+    },
+  ]);
 };
 
 const updateProjectReadme = () => {


### PR DESCRIPTION
## What does this do?

Remove warning from Pull Request Template file as part of the project setup process.

## Why did you do this?

Because it doesn't make sense to have that warning in the context of a project.

## Who/what does this impact?

N/A

## How did you test this?

Locally running the CLI to create a new project and verifying that the warning not present.
