### PR TITLE
fix(cli): set project name in README and Expo config

### DIFF
--- a/cli/setup-project.js
+++ b/cli/setup-project.js
@@ -78,6 +78,15 @@ const updateProjectConfig = async (projectName) => {
         },
       ],
     },
+    {
+      fileName: 'app.config.ts',
+      replacements: [
+        {
+          searchValue: "slug: 'reactnativetemplate'",
+          replaceValue: `slug: '${projectName.toLowerCase()}'`,
+        },
+      ],
+    },
   ]);
 };
 
@@ -138,11 +147,23 @@ const updateGitHubWorkflows = (projectName) => {
   ]);
 };
 
-const updateProjectReadme = () => {
+const updateProjectReadme = (projectName) => {
   projectFilesManager.renameFiles([
     {
       oldFileName: 'README-project.md',
       newFileName: 'README.md',
+    },
+  ]);
+
+  projectFilesManager.replaceFilesContent([
+    {
+      fileName: 'README.md',
+      replacements: [
+        {
+          searchValue: 'Mobile App',
+          replaceValue: projectName,
+        },
+      ],
     },
   ]);
 };
@@ -158,7 +179,7 @@ const setupProject = async (projectName) => {
     updatePackageJson(projectName);
     updateProjectConfig(projectName);
     updateGitHubWorkflows(projectName);
-    updateProjectReadme();
+    updateProjectReadme(projectName);
     consola.success(`Clean up and setup your project 🧹`);
   } catch (error) {
     consola.error(`Failed to clean up project folder`, error);


### PR DESCRIPTION
## What does this do?

Add project name to README and add project slug to Expo config as part of the project setup process.

## Why did you do this?

Because otherwise newly created apps will still have the default app name.

## Who/what does this impact?

This should only affect new projects.

## How did you test this?

Locally running the CLI to create a new project and verifying that the project README file has now the project name, and that Expo config contains the lowercased project name as slug.
