### PR TITLE
chore: guard-for-in

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,7 +72,8 @@ module.exports = {
       },
     ],
     'object-shorthand': 'error',
-    'arrow-body-style': ["error", "as-needed"]
+    'arrow-body-style': ["error", "as-needed"],
+    'guard-for-in': 'error'
   },
   overrides: [
     // Configuration for  translations files (i18next)

--- a/src/api/common/utils.tsx
+++ b/src/api/common/utils.tsx
@@ -51,11 +51,13 @@ type GenericObject = { [key: string]: unknown };
 export const toCamelCase = (obj: GenericObject): GenericObject => {
   const newObj: GenericObject = {};
   for (const key in obj) {
-    if (key.includes('_')) {
-      const newKey = key.replace(/_([a-z])/g, (g) => g[1].toUpperCase());
-      newObj[newKey] = obj[key];
-    } else {
-      newObj[key] = obj[key];
+    if (obj.hasOwnProperty(key)) {
+      if (key.includes('_')) {
+        const newKey = key.replace(/_([a-z])/g, (g) => g[1].toUpperCase());
+        newObj[newKey] = obj[key];
+      } else {
+        newObj[key] = obj[key];
+      }
     }
   }
   return newObj;
@@ -64,16 +66,18 @@ export const toCamelCase = (obj: GenericObject): GenericObject => {
 export const toSnakeCase = (obj: GenericObject): GenericObject => {
   const newObj: GenericObject = {};
   for (const key in obj) {
-    let newKey = key.match(/([A-Z])/g)
-      ? key
-          .match(/([A-Z])/g)!
-          .reduce(
-            (str, c) => str.replace(new RegExp(c), '_' + c.toLowerCase()),
-            key
-          )
-      : key;
-    newKey = newKey.substring(key.slice(0, 1).match(/([A-Z])/g) ? 1 : 0);
-    newObj[newKey] = obj[key];
+    if (obj.hasOwnProperty(key)) {
+      let newKey = key.match(/([A-Z])/g)
+        ? key
+            .match(/([A-Z])/g)!
+            .reduce(
+              (str, c) => str.replace(new RegExp(c), '_' + c.toLowerCase()),
+              key
+            )
+        : key;
+      newKey = newKey.substring(key.slice(0, 1).match(/([A-Z])/g) ? 1 : 0);
+      newObj[newKey] = obj[key];
+    }
   }
   return newObj;
 };


### PR DESCRIPTION

## What does this do?

Adds rule on eslint to be aligned with rule from Sonar: https://sonarqube-developers.rootstrap.net/coding_rules?open=typescript%3AS1535&rule_key=typescript%3AS1535

## Why did you do this?

The for...in statement allows you to loop through the names of all of the properties of an object. The list of properties includes all those properties that were inherited through the prototype chain. This has the side effect of serving up functions when the interest is in data properties. Programs that don’t take this into account can fail.

Therefore, the body of every for...in statement should be wrapped in an if statement that filters which properties are acted upon. It can select for a particular type or range of values, or it can exclude functions, or it can exclude properties from the prototype.

## Who/what does this impact?

Coding experience

## How did you test this?

N/A