### PR TITLE
build(docs): update deploy workflow to trigger when a Release is published

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,8 +2,8 @@
 name: Deploy docs to GitHub Pages
 
 on:
-  push:
-    branches: [main, master]
+  release:
+    types: [published]
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 


### PR DESCRIPTION
## What does this do?

Update Docs deploy workflow to trigger when a Release is published.

## Why did you do this?

- The current workflow runs every time a merge to `master` is done.
- In real life, there are some cases where we can have changes in `master`, but we didn’t release a new Template version yet. For instance, if we are merging small PRs which are part of a big feature.
- In those cases, even if we didn’t release a new version of the template, we are still deploying a new version of the docs.
- **This behaviour isn’t 100% accurate: The deployed documentation could have references to code or features that aren’t yet deployed to the latest version of the Template.**

## Who/what does this impact?

It affects the documentation deployment process. It also impacts people reading the documentation, who will now be reading the version corresponding to the latest version of the template.

## How did you test this?

WIP