### PR TITLE
fix(husky): pre-commit hook not working for new projects

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 pnpm commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 
 
@@ -7,7 +5,7 @@ echo "===\n>> Checking branch name..."
 
 # Check if branch protection is enabled
 if [[ -z $SKIP_BRANCH_PROTECTION ]]; then
-    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    BRANCH=$(git branch --show-current)
     PROTECTED_BRANCHES="^(main|master)"
 
     if [[ $BRANCH =~ $PROTECTED_BRANCHES ]]; then


### PR DESCRIPTION
## What does this do?

1. This PR fixes the pre-commit hook to work with new repositories, i.e. when a new project is created from the CLI and a developer tries to create an initial commit. The issue was being caused by the command that is responsible of retrieving the current branch name. Replacing it with `git branch --show-current` solved the issue.
2. This PR also addresses a warning from husky v9, removing deprecated code.

## Why did you do this?

1. `git rev-parse --abbrev-ref HEAD` doesn't work for new repositories:

```shell
$ mkdir new-project

$ cd new-project

$ git init .
Initialized empty Git repository in /Users/asdolo/dev/new-project/.git/

$ git rev-parse --abbrev-ref HEAD
HEAD
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

However `git branch --show-current` does work:
```shell
$ mkdir new-project

$ cd new-project

$ git init .
Initialized empty Git repository in /Users/asdolo/dev/new-project/.git/

$ git branch --show-current
main
```

2. Because now every time `pre-commit` and `commit-msg` hooks are executed, they show the following warning message:
```shell
husky - DEPRECATED

Please remove the following two lines from .husky/pre-commit:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
```

## Who/what does this impact?

New and current users of the template.

## How did you test this?

1. Locally running the CLI to create a new project. Then trying to do an initial commit successfully.
2. Verifying that the warning doesn't show up anymore.
