### PR TITLE
fix: use getLocales instead of deprecated locale

### DIFF
--- a/src/core/i18n/index.tsx
+++ b/src/core/i18n/index.tsx
@@ -1,4 +1,4 @@
-import { locale } from 'expo-localization';
+import { getLocales } from 'expo-localization';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import { I18nManager } from 'react-native';
@@ -9,7 +9,7 @@ export * from './utils';
 
 i18n.use(initReactI18next).init({
   resources,
-  lng: getLanguage() ?? locale, // TODO: if you are not supporting multiple languages or languages with multiple directions you can set the default value to `en`
+  lng: getLanguage() ?? getLocales()[0].languageTag, // TODO: if you are not supporting multiple languages or languages with multiple directions you can set the default value to `en`
   fallbackLng: 'en',
   compatibilityJSON: 'v3', // By default React Native projects does not support Intl
 

--- a/src/core/i18n/index.tsx
+++ b/src/core/i18n/index.tsx
@@ -9,7 +9,7 @@ export * from './utils';
 
 i18n.use(initReactI18next).init({
   resources,
-  lng: getLanguage() ?? getLocales()[0].languageTag, // TODO: if you are not supporting multiple languages or languages with multiple directions you can set the default value to `en`
+  lng: getLanguage() ?? getLocales()[0]?.languageTag, // TODO: if you are not supporting multiple languages or languages with multiple directions you can set the default value to `en`
   fallbackLng: 'en',
   compatibilityJSON: 'v3', // By default React Native projects does not support Intl
 

--- a/src/core/i18n/index.tsx
+++ b/src/core/i18n/index.tsx
@@ -4,12 +4,13 @@ import { initReactI18next } from 'react-i18next';
 import { I18nManager } from 'react-native';
 
 import { resources } from './resources';
-import { getLanguage } from './utils';
 export * from './utils';
+
+const locales = getLocales()
 
 i18n.use(initReactI18next).init({
   resources,
-  lng: getLanguage() ?? getLocales()[0]?.languageTag, // TODO: if you are not supporting multiple languages or languages with multiple directions you can set the default value to `en`
+  lng: locales[0]?.languageTag, // TODO: if you are not supporting multiple languages or languages with multiple directions you can set the default value to `en`
   fallbackLng: 'en',
   compatibilityJSON: 'v3', // By default React Native projects does not support Intl
 


### PR DESCRIPTION
<!---
❌❌❌
WARNING!!!
Make sure the base repository is `rootstrap/react-native-template` BEFORE creating the Pull Request.
❌❌❌
-->

## What does this do?

Stops using a deprecated function and it replaces it with the right function. Read more about it in the documentation: https://docs.expo.dev/versions/latest/sdk/localization/#constants

## Why did you do this?

The locale constant was deprecated.

![Screenshot 2024-10-17 at 3 28 37 PM](https://github.com/user-attachments/assets/6bf95ae7-53c7-47b7-968e-368026f7bb47)


## Who/what does this impact?

Localization

## How did you test this?

Just tried changing the language and make sure it still worked


https://github.com/user-attachments/assets/9c23d217-5898-4599-9383-520e17ae2077


