### PR TITLE
fix(ci): status check workflows permissions

### DIFF
--- a/.github/workflows/lint-ts.yml
+++ b/.github/workflows/lint-ts.yml
@@ -22,6 +22,9 @@ jobs:
   lint:
     name: Lint TS (eslint, prettier)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: 📦 Checkout project repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
   test:
     name: Tests (jest)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: 📦 Checkout project repo

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -22,6 +22,10 @@ jobs:
   type-check:
     name: Type Check (tsc)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - name: 📦 Checkout project repo
         uses: actions/checkout@v3


### PR DESCRIPTION
## What does this do?

This PR changes the Lint, Test and Type-Check workflows to specifically set the minimum permissions they need.

## Why did you do this?

The workflows (and thus, the status checks of all Pull Requests and pushes) weren't working if the default permissions granted to the `GITHUB_TOKEN` were set to "Read" instead of "Read and Write" in the project repository.

Nonetheless, [GItHub recommends](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions) to "only allow the minimum required access" to the workflow files.


### What is this?

- The `GITHUB_TOKEN` secret is used by all of these workflows to perform operations such as reading our PRs and creating comments on them.
- If no `permissions` are specified in a workflow file, the `GITHUB_TOKEN` will have the default permissions set in the repository configuration (Repository settings > Actions > General > Workflow permissions).
- There are two possible values for the default permissions: "Read and write" and "Read."

| |
| - | 
| <img width="846" alt="image" src="https://github.com/user-attachments/assets/6ca9adc1-d039-4e0d-b956-584bce26a232"> |
| |

- If the default permissions are set to "Read and write", the workflows run without issues.
- If the default permissions are set to "Read", the workflows fail because they require write permissions.
- It may seem that the solution is to simply set "Read and write" as the default permissions in the repository, but this presents two main issues:
  1. Organization owners can prevent you from granting write access to the `GITHUB_TOKEN` at the repository level. In other words, sometimes we can't even change the default permissions to "Read and write." More information [here](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token).
  2. It’s just not recommended. Write permissions will apply to all workflows, which is excessive and could pose a security risk.
- For these two reasons, assuming the default permissions of the `GITHUB_TOKEN` are set to "Read", we recommend specifying and overriding the permissions for each workflow file on a more fine-grained basis.

## Who/what does this impact?

Repositories with restricted access. 

## How did you test this?

I tested the workflow in a temporal test repository.
