### PR TITLE
fix(vscode): i18n-ally not showing inline annotations

### DIFF
--- a/.vscode/i18n-ally-custom-framework.yml
+++ b/.vscode/i18n-ally-custom-framework.yml
@@ -1,0 +1,34 @@
+# An array of strings which contain Language Ids defined by VS Code
+# You can check available language ids here: https://code.visualstudio.com/docs/languages/identifiers
+languageIds:
+  - javascript
+  - typescript
+  - javascriptreact
+  - typescriptreact
+
+# An array of RegExes to find the key usage. **The key should be captured in the first match group**.
+# You should unescape RegEx strings in order to fit in the YAML file
+# To help with this, you can use https://www.freeformatter.com/json-escape.html
+usageMatchRegex:
+  # The following example shows how to detect `t("your.i18n.keys")`
+  # the `{key}` will be placed by a proper keypath matching regex,
+  # you can ignore it and use your own matching rules as well
+  - "[^\\w\\d]translate\\(['\"`]({key})['\"`]"
+  - "(?:text|title)\\s*[:=]\\s*{?['\"`]({key})['\"`]}?"
+
+# A RegEx to set a custom scope range. This scope will be used as a prefix when detecting keys
+# and works like how the i18next framework identifies the namespace scope from the
+# useTranslation() hook.
+# You should unescape RegEx strings in order to fit in the YAML file
+# To help with this, you can use https://www.freeformatter.com/json-escape.html
+scopeRangeRegex: "useTranslation\\(\\s*\\[?\\s*['\"`](.*?)['\"`]"
+
+# An array of strings containing refactor templates.
+# The "$1" will be replaced by the keypath specified.
+# Optional: uncomment the following two lines to use
+
+# refactorTemplates:
+#  - i18n.get("$1")
+
+# If set to true, only enables this custom framework (will disable all built-in frameworks)
+monopoly: true


### PR DESCRIPTION
## What does this do?

Update configuration for vscode's `i18n-ally` extension so it can detect calls to `translate` function. 

## Why did you do this?

Because currently `i18n-ally` is programmed in a way that it only detect calls to the `t` function, but we are using a custom wrapper function of it (`translate`), and it isn't being detected by the extension.

With this change, we can now _see_ actual translations in the code and interact with them using the extension:

| Before | After |
| - | - |
| <img width="650" alt="image" src="https://github.com/user-attachments/assets/c255804e-c582-417b-b7de-9992c5d67488"> | <img width="501" alt="image" src="https://github.com/user-attachments/assets/cf15a1c7-3586-4444-990f-b5b0a937bc15"> |

https://github.com/user-attachments/assets/19cd782b-f212-4b13-9dd0-a829cb1279d9

With the new config file we can also define a custom regex for searching for translation keys. For now I defined a regex for searching translation keys in `title` and `text` props:

| Before | After |
| - | - |
| <img width="390" alt="image" src="https://github.com/user-attachments/assets/b6e0dd9b-e0d0-444d-8ec5-4261fd8f6882"> | <img width="362" alt="image" src="https://github.com/user-attachments/assets/ce4ed75c-6014-4325-b0bc-ca15e4327229"> |

Even if `i18n-ally` supports `i18next`, it doesn't provide a simple way for changing the way it detects the `t` function. But they provide a way to [setup a custom framework](https://github.com/lokalise/i18n-ally/wiki/Custom-Framework), which is what I ended using, and that's why there's a new file called `.vscode/i18n-ally-custom-framework.yml` in this PR.

## Who/what does this impact?

It impact users of the template, both for new an existing projects.

## How did you test this?

Just checking out this branch and reloading the editor, and looking for a file with a call to the `translate` function.
