### PR TITLE
fix(ci): docs not being deployed automatically when releasing a new template version

### DIFF
--- a/.github/workflows/new-template-version.yml
+++ b/.github/workflows/new-template-version.yml
@@ -15,10 +15,18 @@
 #
 
 # 🚨 GITHUB SECRETS REQUIRED:
-#         - GH_TOKEN: A GitHub token with write repo access.
-#           You can generate one from here: https://github.com/settings/tokens
-#           make sure to add it to the repo secrets with the name GH_TOKEN
-#           Attention: Not to be confused with the GITHUB_TOKEN, this is a different token with different permissions.
+# - NEW_TEMPLATE_VERSION_PAT: A fine-grained Personal Access Token.
+#                             This token is used to commit, push and create a new release in the template repository.
+#                             You can generate one from here: https://github.com/settings/tokens?type=beta
+#                             Set the Repository access to "Only select repositories" and select the template repository.
+#                             Set the following Repo permissions:
+#                                 - Contents: Read & write (to commit, push and create a new release)
+#                                 - Metadata: Read-only (mandatory by GitHub)
+#                                 - Actions: Read and write (to allow triggering other workflows, like docs deployment)
+#                             Make sure to add it to the repo secrets with the name NEW_TEMPLATE_VERSION_PAT:
+#                                 - Go to Repository Settings > Secrets and variables > Actions > New repository secret
+#                                   - Name: NEW_TEMPLATE_VERSION_PAT
+#                                   - Value: The Personal Access Token you created
 
 name: New Template Version
 
@@ -45,17 +53,18 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: 🔍 GH_TOKEN
-        if: env.GH_TOKEN == ''
+      - name: Check if Personal Access Token exists
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "GH_TOKEN=${GITHUB_TOKEN}" >> $GITHUB_ENV
+          PAT: ${{ secrets.NEW_TEMPLATE_VERSION_PAT }}
+        if: env.PAT == ''
+        run: |
+          echo "NEW_TEMPLATE_VERSION_PAT secret not found. Please create a fine-grained Personal Access Token following the instructions in the workflow file."
+          exit 1
       - name: 📦 Checkout project repo
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
-
+          token: ${{ secrets.NEW_TEMPLATE_VERSION_PAT }}
       - name: 📝 Git User Setup
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -78,3 +87,4 @@ jobs:
           tag: v${{ env.NEW_VERSION }}
           generateReleaseNotes: true
           draft: false
+          token: ${{ secrets.NEW_TEMPLATE_VERSION_PAT }}


### PR DESCRIPTION
## What does this do?

This PR fixes a bug in the `new-template-version.yml` workflow that prevented `deploy-docs.yml` workflow not to trigger automatically. It also replaces the old classic `GH_TOKEN` token with a modern fine-grained token (`NEW_TEMPLATE_VERSION_PAT`).

The problem was that the old token didn't have [enough permissions](https://github.com/orgs/community/discussions/54574#discussioncomment-10119733) to trigger another workflow.

## Why did you do this?

To fix this bug, which was introduced in [this PR](https://github.com/rootstrap/react-native-template/pull/70).

## Who/what does this impact?

It affects the documentation deployment process. It also impacts people reading the documentation, who will now be reading the version corresponding to the latest version of the template.

## How did you test this?

I pushed this changes in a private fork and ensured both workflows ran as expected.
