### PR TITLE
fix(cli): ProjectFilesManager class not being included in build

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -19,6 +19,7 @@
   "files": [
     "index.js",
     "utils.js",
+    "project-files-manager.js",
     "clone-repo.js",
     "setup-project.js"
   ],


### PR DESCRIPTION
## What does this do?

Add `project-files-manager.js` to the CLI build.

## Why did you do this?

Because it was missing from the build, and it was causing the CLI to crash when trying to import the file:

```shell
node:internal/modules/cjs/loader:1051
  throw err;
  ^

Error: Cannot find module './project-files-manager.js'
Require stack:
- /Users/asdolo/.npm/_npx/fd426691c5ece2b5/node_modules/create-rootstrap-rn-app/setup-project.js
- /Users/asdolo/.npm/_npx/fd426691c5ece2b5/node_modules/create-rootstrap-rn-app/index.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1048:15)
    at Module._load (node:internal/modules/cjs/loader:901:27)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
    at require (node:internal/modules/helpers:119:18)
    at Object.<anonymous> (/Users/asdolo/.npm/_npx/fd426691c5ece2b5/node_modules/create-rootstrap-rn-app/setup-project.js:9:29)
    at Module._compile (node:internal/modules/cjs/loader:1233:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1287:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Module._load (node:internal/modules/cjs/loader:938:12)
    at Module.require (node:internal/modules/cjs/loader:1115:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/asdolo/.npm/_npx/fd426691c5ece2b5/node_modules/create-rootstrap-rn-app/setup-project.js',
    '/Users/asdolo/.npm/_npx/fd426691c5ece2b5/node_modules/create-rootstrap-rn-app/index.js'
  ]
}
```

## Who/what does this impact?

CLI users, new projects.

## How did you test this?

Locally packing the CLI with `pnpm pack` and checking that the new `tgz` now contains the `project-files-manager.js` file.
