### PR TITLE
fix: eas build devclient

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -21,7 +21,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   },
   updates: {
     fallbackToCacheTimeout: 0,
-    url: 'https://u.expo.dev/72fdf440-59f1-493d-96e3-4afad8d7a045',
+    url: `https://u.expo.dev/${Env.EAS_PROJECT_ID}`,
   },
   runtimeVersion: {
     policy: 'appVersion',
@@ -52,6 +52,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         fonts: ['./assets/fonts/Inter.ttf'],
       },
     ],
+    'expo-dev-client',
     'expo-localization',
     'expo-router',
     [


### PR DESCRIPTION
## What does this do?

Adds missing expo-dev-client plugin to app.js, this plugin is required to be able to build using eas build correctly. https://docs.expo.dev/versions/latest/sdk/dev-client/#example-appjson-with-config-plugin

## Why did you do this?

Eas build was finishing successfully and eas update too, but when was needed to install the app in a device it said that it was not a valid version.

## Who/what does this impact?

Eas builds and updates

## How did you test this?

Using eas build and eas update and installing the app on a physical iOS device.
