### PR TITLE
fix: parse nested objects

### DIFF
--- a/src/api/common/utils.spec.tsx
+++ b/src/api/common/utils.spec.tsx
@@ -58,6 +58,49 @@ describe('utils', () => {
   });
 });
 
+describe('toCamelCase with nested objects', () => {
+  it('should convert to camelCase only snake_case keys', () => {
+    const obj = {
+      user: {
+        foo_bar: 'foo',
+        bar_baz: 'bar',
+        nested_object: {
+          another_key: 'value',
+          yet_another_key: 'another value',
+        },
+      },
+    };
+    const expected = {
+      user: {
+        fooBar: 'foo',
+        barBaz: 'bar',
+        nestedObject: {
+          anotherKey: 'value',
+          yetAnotherKey: 'another value',
+        },
+      },
+    };
+    expect(toCamelCase(obj)).toEqual(expected);
+  });
+});
+
+describe('toSnakeCase with nested objects', () => {
+
+  it('should convert to snake_case only camelCase keys', () => {
+    const obj = { user: {
+      fooBar: 'foo',
+      barBaz: 'bar',
+      foo_bar: 'foo',
+      bar_baz: 'bar',
+    }};
+    const expected = { user: {
+      foo_bar: 'foo',
+      bar_baz: 'bar',
+    }}
+    expect(toSnakeCase(obj)).toEqual(expected);
+  });
+});
+
 describe('getUrlParameters', () => {
   it('should return null for a null URL', () => {
     const result = getUrlParameters(null);

--- a/src/api/common/utils.tsx
+++ b/src/api/common/utils.tsx
@@ -48,36 +48,34 @@ export const getNextPageParam: GetPreviousPageParamFunction<
 
 type GenericObject = { [key: string]: unknown };
 
+function isGenericObject(value: unknown): value is GenericObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export const toCamelCase = (obj: GenericObject): GenericObject => {
   const newObj: GenericObject = {};
   for (const key in obj) {
     if (Object.hasOwn(obj, key)) {
-      if (key.includes('_')) {
-        const newKey = key.replace(/_([a-z])/g, (g) => g[1].toUpperCase());
-        newObj[newKey] = obj[key];
+      const newKey = key.replace(/_([a-z])/g, (g) => g[1].toUpperCase());
+      const value = obj[key]
+      if (isGenericObject(value)) {
+        newObj[newKey] = toCamelCase(value);
       } else {
-        newObj[key] = obj[key];
+        newObj[newKey] = value;
       }
     }
   }
   return newObj;
 };
 
+const camelToSnake = (key: string): string => key.replace(/([a-z])([A-Z])/g, "$1_$2").toLowerCase();
+
 export const toSnakeCase = (obj: GenericObject): GenericObject => {
   const newObj: GenericObject = {};
-  for (const key in obj) {
-    if (Object.hasOwn(obj, key)) {
-      let newKey = key.match(/([A-Z])/g)
-        ? key
-            .match(/([A-Z])/g)!
-            .reduce(
-              (str, c) => str.replace(new RegExp(c), `_${c.toLowerCase()}`),
-              key,
-            )
-        : key;
-      newKey = newKey.substring(key.slice(0, 1).match(/([A-Z])/g) ? 1 : 0);
-      newObj[newKey] = obj[key];
-    }
+    
+  for (const [key, value] of Object.entries(obj)) {
+    const newKey = camelToSnake(key);
+    newObj[newKey] = isGenericObject(value) && value !== null ? toSnakeCase(value) : value;
   }
   return newObj;
 };


### PR DESCRIPTION
## What does this do?

There’s an util function: toSnakeCase and toCamelCase that are used in the interceptor to parse all payload in requests and response. This function is not working properly for nested objects.

## Why did you do this?

It's common that the payload sent or received contains nested objects and those keys need to be parsed as well.

## Who/what does this impact?

Payload in response and requests.

## How did you test this?

Unit tests have been added 
