### PR TITLE
Add run-name to build and deploy workflow

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -25,6 +25,7 @@
 #                                   - Value: The Personal Access Token you created
 
 name: 'Build & Deploy'
+run-name: Build & Deploy - ${{inputs.platform}}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This PR fixes that is nice to know when the build is for Android or iOS so now it is included in the name.

Thanks @asdolo


