### PR TITLE
Update Android E2E workflow actions to v4

### DIFF
--- a/.github/workflows/e2e-android-eas-build.yml
+++ b/.github/workflows/e2e-android-eas-build.yml
@@ -32,7 +32,7 @@ jobs:
         run: wget ${{ github.event.inputs.apk-url }} -O ./app-release.apk
 
       - name: Upload Test APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-apk
           path: ./app-release.apk
@@ -52,7 +52,7 @@ jobs:
         run: npm run install-maestro ## We use npm because we don't need to install deps again
 
       - name: Download Test APK
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-apk
           path: ${{ github.workspace }}
@@ -61,7 +61,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: AVD cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: avd-cache
         with:
           path: |
@@ -98,13 +98,13 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-test-logs
           path: ~/.maestro/tests/**/*
 
       - name: Store tests result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e_android_report
           path: |

--- a/.github/workflows/e2e-android-maestro.yml
+++ b/.github/workflows/e2e-android-maestro.yml
@@ -38,7 +38,7 @@ jobs:
           APP_ENV: staging
 
       - name: Upload Test APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-apk
           path: ./android/app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -40,7 +40,7 @@ jobs:
           APP_ENV: staging
 
       - name: Upload Test APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-apk
           path: ./android/app/build/outputs/apk/release/app-release.apk
@@ -60,7 +60,7 @@ jobs:
         run: npm run install-maestro ## We use npm because we don't need to install deps again
 
       - name: Download Test APK
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-apk
           path: ${{ github.workspace }}
@@ -69,7 +69,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: AVD cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: avd-cache
         with:
           path: |
@@ -106,13 +106,13 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-test-logs
           path: ~/.maestro/tests/**/*
 
       - name: Store tests result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e_android_report
           path: |


### PR DESCRIPTION
## Summary
- Update GitHub artifact actions in Android E2E workflows from v3 to v4
- Update AVD cache usage from actions/cache@v3 to actions/cache@v4
- Keep workflow structure, matrix, permissions, secrets, and release/deploy behavior unchanged

## Why
- GitHub Actions artifact v3 is deprecated
- actionlint also detected legacy v3 cache usage in the Android E2E workflows

## Validation
- Ran actionlint against the changed workflows
- Ran git diff --check
- Confirmed no remaining artifact/cache v3 usage in .github/workflows

## Scope
Changed workflows only:
- .github/workflows/e2e-android.yml
- .github/workflows/e2e-android-eas-build.yml
- .github/workflows/e2e-android-maestro.yml
