### PR TITLE
Fix/ build action

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ${{ inputs.platform == 'ios' && 'macos-latest' || 'ubuntu-latest' }}
     permissions:
       contents: write
-    environment: ${{ github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'staging' || github.ref_name == 'qa' && 'qa' || github.ref_name == 'development' && 'development' || github.ref_name == 'fix/actions' && 'qa' }}
+    environment: ${{ github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'staging' || github.ref_name == 'qa' && 'qa' || github.ref_name == 'development' && 'development' }}
     steps:
       - name: Set environment variable
         run: |
@@ -91,8 +91,6 @@ jobs:
             echo "ENV=qa" >> $GITHUB_ENV
           elif [[ "${{ github.ref_name }}" == "development" ]]; then
             echo "ENV=development" >> $GITHUB_ENV
-          elif [[ "${{ github.ref_name }}" == "fix/actions" ]]; then
-            echo "ENV=qa" >> $GITHUB_ENV
           else
             echo "Invalid branch: ${{ github.ref_name }}. You can only build for main, staging, qa or development branches."
             exit 1

--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -106,17 +106,17 @@ jobs:
             exit 1
           fi
 
-      - name: 📦 Setup Expo and EAS
-        uses: expo/expo-github-action@v8
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
       - name: 📦 Checkout project repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.NEW_VERSION_NUMBER_PAT }}
+
+      - name: 📦 Setup Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 📦 Setup Node + PNPM + install deps
         uses: ./.github/actions/setup-node-pnpm-install

--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ${{ inputs.platform == 'ios' && 'macos-latest' || 'ubuntu-latest' }}
     permissions:
       contents: write
-    environment: ${{ github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'staging' || github.ref_name == 'qa' && 'qa' || github.ref_name == 'development' && 'development' }}
+    environment: ${{ github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'staging' || github.ref_name == 'qa' && 'qa' || github.ref_name == 'development' && 'development' || github.ref_name == 'fix/actions' && 'qa' }}
     steps:
       - name: Set environment variable
         run: |
@@ -91,6 +91,8 @@ jobs:
             echo "ENV=qa" >> $GITHUB_ENV
           elif [[ "${{ github.ref_name }}" == "development" ]]; then
             echo "ENV=development" >> $GITHUB_ENV
+          elif [[ "${{ github.ref_name }}" == "fix/actions" ]]; then
+            echo "ENV=qa" >> $GITHUB_ENV
           else
             echo "Invalid branch: ${{ github.ref_name }}. You can only build for main, staging, qa or development branches."
             exit 1


### PR DESCRIPTION
#### Jira board reference:

- [Test Build via github action ](https://app.notion.com/p/rootstrap/Test-Build-via-github-action-37659347eba6804a8f9fdb3262eac228?v=1197be7bd58c47b58e369022eb1f6497&source=copy_link)

---

## What does this do?

Fixes the step ordering in the EAS build GitHub Actions workflow. Moves the `actions/checkout` step to run **before** `expo/expo-github-action`, so that the repo is available on disk when the Expo/EAS setup step executes.

---

## Why did you do this?

The `expo/expo-github-action` step was running before `actions/checkout`, which meant the local `.github/actions/setup-node-pnpm-install` composite action (referenced in a later step) and any repo-relative files were not yet available. Reordering ensures the workspace is fully checked out before EAS tooling is initialized.

## Who/what does this impact?

Affects all EAS builds triggered via the `eas-build.yml` workflow (main, staging, qa, development branches). No application code changes.

## How did you test this?

I tested the workflow 

https://github.com/rootstrap/react-native-template/actions/runs/27714374165

https://github.com/rootstrap/react-native-template/actions/runs/27700319882

<img width="1310" height="370" alt="Captura de pantalla 2026-06-23 a la(s) 11 16 46 a m" src="https://github.com/user-attachments/assets/d865faa6-9e10-43d9-888c-2bcbc6425317" />


---

#### Notes:

The two revert/test commits (`fix: testing purposes of action` + its revert) are squash candidates before merge — the net change is just the step reorder in `eas-build.yml`.

---

## **Screenshots / Previews**

N/A — CI workflow change only, no UI impact.