### PR TITLE
refactor(router): move screen options from layouts into screen files

### DIFF
--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -1,13 +1,7 @@
-import { Link, Redirect, SplashScreen, Tabs } from 'expo-router';
+import { Redirect, SplashScreen, Tabs } from 'expo-router';
 import { useCallback, useEffect } from 'react';
 
 import { useAuth } from '@/components/providers/auth';
-import { Pressable, Text } from '@/components/ui';
-import {
-  Feed as FeedIcon,
-  Settings as SettingsIcon,
-  Style as StyleIcon,
-} from '@/components/ui/icons';
 import { useIsFirstTime } from '@/lib';
 
 export default function TabLayout() {
@@ -29,43 +23,5 @@ export default function TabLayout() {
   if (!isAuthenticated && ready) {
     return <Redirect href="/sign-in" />;
   }
-  return (
-    <Tabs>
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: 'Feed',
-          tabBarIcon: ({ color }) => <FeedIcon color={color} />,
-          headerRight: () => <CreateNewPostLink />,
-          tabBarButtonTestID: 'feed-tab',
-        }}
-      />
-      <Tabs.Screen
-        name="style"
-        options={{
-          title: 'Style',
-          tabBarIcon: ({ color }) => <StyleIcon color={color} />,
-          tabBarButtonTestID: 'style-tab',
-        }}
-      />
-      <Tabs.Screen
-        name="settings"
-        options={{
-          title: 'Settings',
-          tabBarIcon: ({ color }) => <SettingsIcon color={color} />,
-          tabBarButtonTestID: 'settings-tab',
-        }}
-      />
-    </Tabs>
-  );
-}
-
-function CreateNewPostLink() {
-  return (
-    <Link href="/feed/add-post" asChild>
-      <Pressable>
-        <Text className="px-3 text-primary-300">Create</Text>
-      </Pressable>
-    </Link>
-  );
+  return <Tabs screenOptions={{ headerShown: true }} />;
 }

--- a/src/app/(app)/index.tsx
+++ b/src/app/(app)/index.tsx
@@ -1,9 +1,35 @@
-import { FocusAwareStatusBar, View } from '@/components/ui';
+import { Link, Tabs } from 'expo-router';
+
+import {
+  FocusAwareStatusBar,
+  Pressable,
+  Text,
+  View,
+} from '@/components/ui';
+import { Feed as FeedIcon } from '@/components/ui/icons';
 
 export default function Feed() {
   return (
     <View className="flex-1 ">
+      <Tabs.Screen
+        options={{
+          title: 'Feed',
+          tabBarIcon: ({ color }) => <FeedIcon color={color} />,
+          headerRight: () => <CreateNewPostLink />,
+          tabBarButtonTestID: 'feed-tab',
+        }}
+      />
       <FocusAwareStatusBar />
     </View>
+  );
+}
+
+function CreateNewPostLink() {
+  return (
+    <Link href="/feed/add-post" asChild>
+      <Pressable>
+        <Text className="px-3 text-primary-300">Create</Text>
+      </Pressable>
+    </Link>
   );
 }

--- a/src/app/(app)/settings.tsx
+++ b/src/app/(app)/settings.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines-per-function */
-import { Link } from 'expo-router';
+import { Link, Tabs } from 'expo-router';
 import { useColorScheme } from 'nativewind';
 import * as React from 'react';
 import { showMessage } from 'react-native-flash-message';
@@ -18,7 +18,7 @@ import {
   Text,
   View,
 } from '@/components/ui';
-import { Website } from '@/components/ui/icons';
+import { Settings as SettingsIcon, Website } from '@/components/ui/icons';
 import { translate } from '@/lib';
 import { Env } from '@/lib/env';
 
@@ -44,6 +44,13 @@ export default function Settings() {
 
   return (
     <>
+      <Tabs.Screen
+        options={{
+          title: 'Settings',
+          tabBarIcon: ({ color }) => <SettingsIcon color={color} />,
+          tabBarButtonTestID: 'settings-tab',
+        }}
+      />
       <FocusAwareStatusBar />
       <ScrollView>
         <View className="flex-1 gap-2 p-4">

--- a/src/app/(app)/style.tsx
+++ b/src/app/(app)/style.tsx
@@ -1,3 +1,4 @@
+import { Tabs } from 'expo-router';
 import * as React from 'react';
 
 import { Buttons } from '@/components/buttons';
@@ -5,10 +6,18 @@ import { Colors } from '@/components/colors';
 import { Inputs } from '@/components/inputs';
 import { Typography } from '@/components/typography';
 import { FocusAwareStatusBar, SafeAreaView, ScrollView } from '@/components/ui';
+import { Style as StyleIcon } from '@/components/ui/icons';
 
 export default function Style() {
   return (
     <>
+      <Tabs.Screen
+        options={{
+          title: 'Style',
+          tabBarIcon: ({ color }) => <StyleIcon color={color} />,
+          tabBarButtonTestID: 'style-tab',
+        }}
+      />
       <FocusAwareStatusBar />
       <ScrollView className="px-4">
         <SafeAreaView className="flex-1">

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -4,7 +4,6 @@ import { ThemeProvider } from '@react-navigation/native';
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { StyleSheet } from 'react-native';
 import FlashMessage from 'react-native-flash-message';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -37,38 +36,24 @@ SplashScreen.setOptions({
 
 function GuardedStack() {
   const { isAuthenticated } = useAuth();
-  const { t } = useTranslation();
   const [isFirstTime] = useIsFirstTime();
 
   return (
     <Stack>
       <Stack.Protected guard={isFirstTime}>
-        <Stack.Screen name="onboarding" options={{ headerShown: false }} />
+        <Stack.Screen name="onboarding" />
       </Stack.Protected>
 
       <Stack.Protected guard={isAuthenticated}>
-        <Stack.Screen name="(app)" options={{ headerShown: false }} />
-        <Stack.Screen
-          name="update-password"
-          options={{
-            title: t('updatePassword.title'),
-          }}
-        />
+        <Stack.Screen name="(app)" />
+        <Stack.Screen name="update-password" />
       </Stack.Protected>
 
       <Stack.Protected guard={!isAuthenticated}>
-        <Stack.Screen name="sign-in" options={{ headerShown: false }} />
+        <Stack.Screen name="sign-in" />
         <Stack.Screen name="sign-up" />
         <Stack.Screen name="forgot-password" />
       </Stack.Protected>
-
-      <Stack.Screen
-        name="www"
-        options={{
-          presentation: 'modal',
-          title: '',
-        }}
-      />
     </Stack>
   );
 }

--- a/src/app/onboarding.tsx
+++ b/src/app/onboarding.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from 'expo-router';
+import { Stack, useRouter } from 'expo-router';
 
 import { Cover } from '@/components/cover';
 import {
@@ -17,6 +17,7 @@ export default function Onboarding() {
 
   return (
     <View className="flex h-full items-center justify-center">
+      <Stack.Screen options={{ headerShown: false }} />
       <FocusAwareStatusBar />
       <View className="w-full flex-1">
         <Cover />

--- a/src/app/sign-in.tsx
+++ b/src/app/sign-in.tsx
@@ -1,4 +1,5 @@
 import type { LoginFormProps } from '@/components/login-form';
+import { Stack } from 'expo-router';
 import * as React from 'react';
 
 import { showMessage } from 'react-native-flash-message';
@@ -16,6 +17,7 @@ export default function Login() {
   };
   return (
     <>
+      <Stack.Screen options={{ headerShown: false }} />
       <FocusAwareStatusBar />
       <LoginForm onSubmit={onSubmit} isLoading={isPending} />
     </>

--- a/src/app/update-password.tsx
+++ b/src/app/update-password.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useNavigation } from 'expo-router';
+import { Stack, useNavigation } from 'expo-router';
 import * as React from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -64,6 +64,7 @@ export default function UpdatePassword() {
 
   return (
     <>
+      <Stack.Screen options={{ title: t('updatePassword.title') }} />
       <FocusAwareStatusBar />
       <KeyboardAvoidingView>
         <View className="gap-8 p-4">

--- a/src/app/www.tsx
+++ b/src/app/www.tsx
@@ -1,6 +1,5 @@
-import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import * as React from 'react';
-import { useEffect } from 'react';
 import { View } from 'react-native';
 import { WebView } from 'react-native-webview';
 
@@ -10,19 +9,16 @@ import { translate } from '@/lib';
 export default function WWW() {
   const router = useRouter();
   const { url, title } = useLocalSearchParams();
-  const navigation = useNavigation();
 
-  useEffect(() => {
-    if (title !== undefined) {
-      navigation.setOptions({
-        title,
-      });
-    }
-  }, [navigation, title]);
+  const screenOptions = {
+    presentation: 'modal',
+    title: typeof title === 'string' ? title : '',
+  } as const;
 
   if (url === undefined || typeof url !== 'string') {
     return (
       <View className="flex-1 items-center justify-center bg-white">
+        <Stack.Screen options={screenOptions} />
         <Text className="text-lg text-red-500">
           {translate('www.invalidUrl')}
         </Text>
@@ -32,6 +28,7 @@ export default function WWW() {
 
   return (
     <View className="flex-1 bg-white">
+      <Stack.Screen options={screenOptions} />
       <WebView
         source={{ uri: url }}
         className="flex-1"


### PR DESCRIPTION
#### Jira board reference:

- [Refactor expo-router Layout files](https://app.notion.com/p/rootstrap/Refactor-expo-router-Layout-files-1a659347eba680778273c4b5b4b16ea1)

---

## What does this do?

Moves per-screen navigation options out of the expo-router layout files and into the screens themselves. `src/app/(app)/_layout.tsx` drops its three `Tabs.Screen` declarations and returns `<Tabs screenOptions={...} />`; each tab now declares its own title, icon and `tabBarButtonTestID` via `Tabs.Screen`. In the root stack, the options for `onboarding`, `sign-in`, `update-password` and `www` moved to those screen files. `CreateNewPostLink` moved from the tabs layout to `(app)/index.tsx`, the only place it is used, and `www.tsx` no longer needs a `useEffect` with `navigation.setOptions` because the modal presentation and title come from a single `Stack.Screen`.

---

## Why did you do this?

Declaring every screen in its layout means each new route has to be registered in two places. With the options living next to the screen they describe, adding a route is just adding a file, and the layout only carries what is genuinely shared. `src/app/feed/` already followed this pattern, so this brings the rest of the app in line.

## Who/what does this impact?

- Navigation layer only — no API, auth or business logic changes.
- `src/app/_layout.tsx`, `src/app/(app)/_layout.tsx`, the three tab screens, and `onboarding`, `sign-in`, `update-password`, `www`.
- **Tab order changes.** Without explicit `Tabs.Screen` entries in the layout, expo-router orders tabs by filesystem: Feed, Settings, Style — previously Feed, Style, Settings. This is inherent to the pattern; pinning the order would mean putting the declarations back.

## How did you test this?

Ran `pnpm type-check`, `pnpm lint` and `pnpm test:ci` — all pass (139 tests). Not yet exercised on a device: tab order, a possible header flash on the screens that set `headerShown: false` from the screen file, and the `www` modal presentation all need a real run.

- [ ] Tested on iOS
- [ ] Tested on Android
- [ ] Tested on a small device
- [ ] Tested on a real device
- [ ] Tested all flows related with this PR changes
- [ ] Tested accessibility
- [ ] Added tests

---

#### Notes:

- The `Stack.Screen` entries in `src/app/_layout.tsx` are kept, but stripped of their `options`. They are the children of `Stack.Protected` and removing them would delete the onboarding/auth guards. The ticket predates `Stack.Protected`, so this is the one part that cannot be applied literally.
- `sign-up` and `forgot-password` did not get example `options`: they currently have none, and adding a `title` would mean hardcoding a string, which `AGENTS.md` forbids. Happy to add translation keys for them if wanted.

---

## **Screenshots / Previews**

<!---
📸 Add screenshots or screen recordings if relevant.
-->
