### PR TITLE
feat(cli): create develop, qa and main branches on project creation

### DIFF
--- a/cli/setup-project.js
+++ b/cli/setup-project.js
@@ -16,6 +16,12 @@ let projectFilesManager;
 const DEFAULT_BRANCH = 'develop';
 const ADDITIONAL_BRANCHES = ['qa', 'main'];
 
+const hasGitIdentity = async (options) => {
+  const name = await execShellCommand('git config user.name || true', options);
+  const email = await execShellCommand('git config user.email || true', options);
+  return Boolean(name.trim() && email.trim());
+};
+
 // Branches can only be created once a commit exists, so the initial commit
 // happens before renaming the current branch and branching off it.
 const initializeProjectRepository = async (projectName) => {
@@ -23,8 +29,12 @@ const initializeProjectRepository = async (projectName) => {
 
   await execShellCommand('git init', options);
   await execShellCommand('git add -A', options);
+
+  const identityFlags = (await hasGitIdentity(options))
+    ? ''
+    : '-c user.name="Rootstrap Template" -c user.email="template@rootstrap.com"';
   await execShellCommand(
-    'git commit -m "chore: initial commit from Rootstrap React Native template"',
+    `git ${identityFlags} commit -m "chore: initial commit from Rootstrap React Native template"`,
     options,
   );
   await execShellCommand(`git branch -M ${DEFAULT_BRANCH}`, options);
@@ -55,7 +65,7 @@ const removeUnrelatedFiles = () => {
 };
 
 // Update package.json infos, name and set version to 0.0.1 + add initial version to rsMetadata
-const updatePackageJson = async (projectName) => {
+const updatePackageJson = (projectName) => {
   const packageJsonPath =
     projectFilesManager.getAbsoluteFilePath('package.json');
 
@@ -76,7 +86,7 @@ const updatePackageJson = async (projectName) => {
   fs.writeJsonSync(packageJsonPath, packageJson, { spaces: 2 });
 };
 
-const updateProjectConfig = async (projectName) => {
+const updateProjectConfig = (projectName) => {
   projectFilesManager.replaceFilesContent([
     {
       fileName: 'env.js',

--- a/cli/setup-project.js
+++ b/cli/setup-project.js
@@ -13,8 +13,25 @@ const ProjectFilesManager = require('./project-files-manager.js');
  */
 let projectFilesManager;
 
+const DEFAULT_BRANCH = 'develop';
+const ADDITIONAL_BRANCHES = ['qa', 'main'];
+
+// Branches can only be created once a commit exists, so the initial commit
+// happens before renaming the current branch and branching off it.
 const initializeProjectRepository = async (projectName) => {
-  await execShellCommand(`cd ${projectName} && git init && cd ..`);
+  const options = { cwd: projectName };
+
+  await execShellCommand('git init', options);
+  await execShellCommand('git add -A', options);
+  await execShellCommand(
+    'git commit -m "chore: initial commit from Rootstrap React Native template"',
+    options,
+  );
+  await execShellCommand(`git branch -M ${DEFAULT_BRANCH}`, options);
+
+  for (const branch of ADDITIONAL_BRANCHES) {
+    await execShellCommand(`git branch ${branch}`, options);
+  }
 };
 
 const installDependencies = async (projectName) => {
@@ -211,12 +228,13 @@ const setupProject = async (projectName) => {
 
   try {
     removeUnrelatedFiles();
-    await initializeProjectRepository(projectName);
     updatePackageJson(projectName);
     updateProjectConfig(projectName);
     updateGitHubWorkflows(projectName);
     updateProjectReadme(projectName);
     updateAgentDocs(projectName);
+    // Runs last so the initial commit contains the fully set up project
+    await initializeProjectRepository(projectName);
     consola.success(`Clean up and setup your project 🧹`);
   } catch (error) {
     consola.error(`Failed to clean up project folder`, error);

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -10,7 +10,7 @@ const execShellCommand = (cmd, options) => {
     exec(cmd, options, (error, stdout, stderr) => {
       if (error) {
         console.warn(error);
-        reject(error);
+        return reject(error);
       }
       resolve(stdout || stderr);
     });

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -5,9 +5,9 @@ const { consola } = require('consola');
 const UPSTREAM_REPOSITORY = "obytes/react-native-template-obytes";
 const TEMPLATE_REPOSITORY = "rootstrap/react-native-template";
 
-const execShellCommand = (cmd) => {
+const execShellCommand = (cmd, options) => {
   return new Promise((resolve, reject) => {
-    exec(cmd, (error, stdout, stderr) => {
+    exec(cmd, options, (error, stdout, stderr) => {
       if (error) {
         console.warn(error);
         reject(error);


### PR DESCRIPTION
#### Jira board reference:

- [Agregar paso de inicializar GIT al script crear proyecto](https://app.notion.com/p/rootstrap/Agregar-paso-de-inicializar-GIT-al-script-crear-proyecto-37659347eba68060a1c6dc3cefe3d283)

---

## What does this do?

The generator already ran `git init`, but left the repository with no commit and a single default branch. It now creates the initial commit and sets up the branch layout the ticket asks for: the current branch is renamed to `develop`, and `qa` and `main` are branched off it. The generated project ends with a clean working tree, three branches, and `develop` checked out.

The `git init` step also moved to the end of `setupProject`. It used to run before the CLI rewrote `package.json`, `env.js`, the README, the workflows and the agent docs, so an initial commit made there would have excluded every one of those changes.

---

## Why did you do this?

New projects started life with no commit at all, so the first thing every developer had to do was stage a few hundred files by hand and invent a branch structure. Doing it in the generator makes that consistent across projects and matches the branches the deploy workflows already expect.

## Who/what does this impact?

- `cli/setup-project.js` and `cli/utils.js` — generator only, no app code.
- `execShellCommand` now takes an optional `options` argument, forwarded to `exec`. Backwards compatible: every existing call site passes nothing. The new code uses `{ cwd: projectName }` instead of `cd ${projectName} && …`, which avoids the interpolation issue flagged by Copilot in #156.

## How did you test this?

Ran the generator against a fresh `master` clone and inspected the result: three branches (`develop`, `qa`, `main`), `HEAD` on `develop`, exactly one commit, and a clean working tree. Confirmed the commit contains the CLI's own edits — `package.json` in the generated project reads `name: gitapp`, `version: 0.0.1`, `rsMetadata.templateVersion: 1.9.0`. `pnpm lint` and `pnpm type-check` pass.

- [ ] Tested on iOS
- [ ] Tested on Android
- [ ] Tested on a small device
- [ ] Tested on a real device
- [x] Tested all flows related with this PR changes
- [ ] Tested accessibility
- [ ] Added tests

---

#### Notes:

- The ticket also asks to "make default". That cannot be done from the generator: the default branch is a property of the GitHub remote, which does not exist yet at that point. `develop` is left as the checked-out branch, so it becomes the default when the repo is first pushed. Setting it explicitly would need `gh repo edit --default-branch develop` after the remote exists — happy to add that as a documented follow-up step if wanted.
- No `--no-verify` on the initial commit: at that point in the flow `pnpm install` has not run yet, so husky is not installed and no hooks fire.

---

## **Screenshots / Previews**

<!---
📸 Add screenshots or screen recordings if relevant.
-->
